### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/324/97/85632497.geojson
+++ b/data/856/324/97/85632497.geojson
@@ -488,6 +488,9 @@
         "wk:page":"Christmas Island"
     },
     "wof:country":"CX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"65e2a5735c90e75321b815c3346b4353",
     "wof:hierarchy":[
         {
@@ -497,7 +500,7 @@
         }
     ],
     "wof:id":85632497,
-    "wof:lastmodified":1561769485,
+    "wof:lastmodified":1582379102,
     "wof:name":"Christmas Island",
     "wof:parent_id":85632793,
     "wof:placetype":"dependency",

--- a/data/856/722/79/85672279.geojson
+++ b/data/856/722/79/85672279.geojson
@@ -179,6 +179,9 @@
         "qs:id":1085826
     },
     "wof:country":"CX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56c91fb8abc99fa56b756448c4f69c71",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1561769485,
+    "wof:lastmodified":1582379102,
     "wof:name":"Christmas Island",
     "wof:parent_id":85632495,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.