### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/890/440/049/890440049.geojson
+++ b/data/890/440/049/890440049.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0641\u0644\u0627\u064a\u0646\u063a \u0641\u064a\u0634 \u0643\u0648\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0644\u0627\u064a\u0646\u062c \u0641\u064a\u0634 \u0643\u0648\u0641"
+    ],
     "name:ast_x_preferred":[
         "Flying Fish Cove"
     ],
@@ -33,6 +36,12 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0424\u043b\u0430\u0456\u043d-\u0424\u0456\u0448-\u041a\u043e\u045e\u0432"
+    ],
+    "name:bel_x_variant":[
+        "\u0424\u043b\u0430\u0456\u043d-\u0424\u0456\u0448-\u041a\u043e\u045e\u0432"
+    ],
+    "name:ben_x_preferred":[
+        "\u09ab\u09cd\u09b2\u09be\u0987\u0982 \u09ab\u09bf\u09b6 \u0995\u09cb\u09ad"
     ],
     "name:bos_x_preferred":[
         "Flying Fish Cove"
@@ -88,6 +97,9 @@
     "name:eng_x_variant":[
         "Flying Fish Cove"
     ],
+    "name:epo_x_preferred":[
+        "Flying Fish Cove"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0644\u0627\u06cc\u0646\u06af \u0641\u06cc\u0634 \u06a9\u0627\u0648"
     ],
@@ -107,6 +119,9 @@
         "The Settlement"
     ],
     "name:fra_x_variant":[
+        "Flying Fish Cove"
+    ],
+    "name:gle_x_preferred":[
         "Flying Fish Cove"
     ],
     "name:glg_x_preferred":[
@@ -148,11 +163,20 @@
     "name:kor_x_preferred":[
         "\ud50c\ub77c\uc789\ud53c\uc2dc\ucf54\ube0c"
     ],
+    "name:lav_x_preferred":[
+        "Flaiingfi\u0161kova"
+    ],
     "name:lij_x_preferred":[
         "The Settlement"
     ],
+    "name:lit_x_preferred":[
+        "Flajing Fi\u0161 Kovas"
+    ],
     "name:mkd_x_preferred":[
         "\u0424\u043b\u0430\u0438\u043d\u0433 \u0424\u0438\u0448 \u041a\u043e\u0443\u0432"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0641\u0644\u0627\u06cc\u0646\u06af \u0641\u06cc\u0634 \u06a9\u0627\u0648"
     ],
     "name:nld_x_preferred":[
         "Flying Fish Cove"
@@ -226,6 +250,15 @@
     "name:war_x_preferred":[
         "Flying Fish Cove"
     ],
+    "name:wuu_x_preferred":[
+        "\u98de\u9c7c\u6e7e"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10e4\u10da\u10d0\u10d8\u10dc\u10d2-\u10e4\u10d8\u10e8-\u10d9\u10dd\u10d5\u10d8"
+    ],
+    "name:yue_x_preferred":[
+        "\u98db\u9b5a\u7063"
+    ],
     "name:zho_x_preferred":[
         "\u98de\u9c7c\u6e7e"
     ],
@@ -267,7 +300,7 @@
         }
     ],
     "wof:id":890440049,
-    "wof:lastmodified":1566709956,
+    "wof:lastmodified":1690868607,
     "wof:name":"Flying Fish Cove",
     "wof:parent_id":404550147,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.